### PR TITLE
Imports: Allow for a Native XML file to be imported if the primary contact ID is not provided

### DIFF
--- a/plugins/importexport/native/filter/NativeXmlPKPPublicationFilter.php
+++ b/plugins/importexport/native/filter/NativeXmlPKPPublicationFilter.php
@@ -88,7 +88,10 @@ class NativeXmlPKPPublicationFilter extends NativeImportFilter
         $publicationId = Repo::publication()->dao->insert($publication);
         $publication = Repo::publication()->get($publicationId);
         // Non-persisted temporary ID, will be updated and stored once the authors get parsed
-        $publication->setData('primaryContactId', $node->getAttribute('primary_contact_id'));
+        $pci = $node->getAttribute('primary_contact_id');
+        if($pci) {
+            $publication->setData('primaryContactId', $pci);
+        }
         $deployment->setPublication($publication);
 
         for ($n = $node->firstChild; $n !== null; $n = $n->nextSibling) {


### PR DESCRIPTION
This pull request includes a fix for an edge case where importing native XML which does not contain a primary contact as it would throw a SQL integrity constraint error.